### PR TITLE
Tune threads and workers for puma

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma -p $PORT -t 1:5 -w 2
+web: bundle exec puma -p $PORT -t 1:5 -w 1

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma -p $PORT
+web: bundle exec puma -p $PORT -t 1:5 -w 2


### PR DESCRIPTION
Deploying with Heroku button to a single dyno - tested in Safari and Chrome - neither worked. In Chrome web socket shows as already closing.

Scaling to two dynos works.

Scaling back to one dyno and updating the procfile to tune the threads and workers for Puma got it running..
